### PR TITLE
Always defined node_name_map attribute

### DIFF
--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -20,7 +20,7 @@ class InfinibandCollector(object):
 
         self.input_file = input_file
         self.node_name_map = node_name_map
-        
+
         if 'NODE_NAME_MAP' in os.environ:
             self.node_name_map = os.environ['NODE_NAME_MAP']
 

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -19,10 +19,9 @@ class InfinibandCollector(object):
             self.can_reset_counter = False
 
         self.input_file = input_file
-
-        if node_name_map:
-            self.node_name_map = node_name_map
-        elif 'NODE_NAME_MAP' in os.environ:
+        self.node_name_map = node_name_map
+        
+        if 'NODE_NAME_MAP' in os.environ:
             self.node_name_map = os.environ['NODE_NAME_MAP']
 
         self.node_name = {}


### PR DESCRIPTION
If node_name_map argument of InfinibandCollector constructor is None (when the option is not used on the command-line for example), self.node_name_map is never defined. This can raise multiple AttributeError exception throughout the code.

This change prevents AttributeError exception when node_name_map is None.