### PR TITLE
Exit nicely when ibqueryerrors is not executable

### DIFF
--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -3,6 +3,7 @@ import time
 import argparse
 import subprocess
 import os
+import sys
 
 from prometheus_client.core import REGISTRY, CounterMetricFamily, \
     GaugeMetricFamily
@@ -318,6 +319,29 @@ class InfinibandCollector(object):
             yield self.metrics[gauge_name]
 
 
+# stolen from stackoverflow (http://stackoverflow.com/a/377028)
+def which(program):
+    """
+    Python implementation of the which command
+    """
+    def is_exe(fpath):
+        """ helper """
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, _ = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        paths = os.getenv("PATH", "/usr/bin:/usr/sbin:/sbin:/bin")
+
+        for path in paths.split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None         
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Prometheus collector for a infiniband fabric')
@@ -347,7 +371,11 @@ var NODE_NAME_MAP')
 
     args = parser.parse_args()
 
-    start_http_server(args.port)
+    if not which("ibqueryerrors"):
+	    print('Cannot find an executable ibqueryerrors binary in PATH')
+	    sys.exit(1)
+
+        start_http_server(args.port)
     REGISTRY.register(InfinibandCollector(
         args.can_reset_counter,
         args.input_file,


### PR DESCRIPTION
Prevents runtime exception when ibqueryerrors not installed or executable:

Before:
```
Traceback (most recent call last):
  File "infiniband-exporter.py", line 354, in <module>
    args.node_name_map))
  File "/usr/lib/python2.7/site-packages/prometheus_client/registry.py", line 24, in register
    names = self._get_names(collector)
  File "/usr/lib/python2.7/site-packages/prometheus_client/registry.py", line 64, in _get_names
    for metric in desc_func():
  File "infiniband-exporter.py", line 274, in collect
    stdout=subprocess.PIPE)
  File "/usr/lib64/python2.7/subprocess.py", line 394, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.7/subprocess.py", line 1047, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

```
After:
```
python2 infiniband-exporter.py 
Cannot find an executable ibqueryerrors binary in PATH
```
