### PR TITLE
Add header line for running the exporter as Python3 program directly

### DIFF
--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import re
 import time
 import argparse


### PR DESCRIPTION
Hi,

to execute the exporter directly I have added the required line as the header into the exporter program.

It has at least 2 reasons:

1. It is the main entry point and should be executable directly without involving the interpreter directly
2. We can run it directly for testing, ...

I assumed, that the exporter will run at least with version 3, so I specified explicitly.
Would not keep compatibility with version 2 anyway, so I think it is a good call here.

What do you think, will you merge it into the master?

Best 
Gabriele