### PR TITLE
Ignore ibqueryerrors executable check if input file is set.

### DIFF
--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -478,7 +478,11 @@ var NODE_NAME_MAP')
         logging.basicConfig(level=logging.INFO,
                             format='%(asctime)s - %(levelname)s - %(message)s')
 
-    if not which("ibqueryerrors"):
+    if args.input_file and not os.path.isfile(args.input_file):
+        logging.critical("Input file does not exist: %s", args.input_file)
+        sys.exit(1)
+
+    if args.input_file is None and not which("ibqueryerrors"):
         logging.critical('Cannot find an executable ibqueryerrors binary in PATH')  # noqa: E501
         sys.exit(1)
 


### PR DESCRIPTION
Hi,

I would like to work on the exporter locally without the need to have `ibqueryerrors` available.  

So executing it with just an input file will cause the exporter to ignore the check for the `ibqueryerrors` executable.

Best
Gabriele