### PR TITLE
Do not export zero counter values.

### DIFF
--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -183,9 +183,6 @@ catched on stderr of ibqueryerrors'
 
     def parse_counter(self, s):
         counters = {}
-        # init all to zero
-        for counter in self.counter_info.keys():
-            counters[counter] = 0
 
         for counter in re.findall(r'\[(.*?)\]', s):
             c = re.search(r'(\w+) == (\d+).*?', counter)
@@ -273,7 +270,7 @@ catched on stderr of ibqueryerrors'
                         m_link.group('node_name')],
                         m_link.group(gauge))
 
-                for counter in self.counter_info.keys():
+                for counter in counters:
                     self.metrics[counter].add_metric([
                         switch_name,
                         guid,


### PR DESCRIPTION
Hi,

I would suggest to drop 0 values on counter metrics.  
By now I do not see any reason to keep them...  
In our case we could save up to ~55% of the counter metrics.  
As far as I know the rate function for plotting the rate requires at least two values not zero.
So keeping the first value with 0 would not be required. This aspect could have been important to keep 0 values.  

Best
Gabriele


