### PR TITLE
Show scrape error on missing metric description

### DIFF
--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -256,6 +256,34 @@ catched on stderr of ibqueryerrors'
         else:
             return False
 
+    def init_switch_metrics(self):
+
+        for gauge_name in self.gauge_info:
+            self.metrics[gauge_name] = GaugeMetricFamily(
+                'infiniband_' + gauge_name.lower(),
+                self.gauge_info[gauge_name]['help'],
+                labels=[
+                    'local_name',
+                    'local_guid',
+                    'local_port',
+                    'remote_guid',
+                    'remote_port',
+                    'remote_name'
+                ])
+
+        for counter_name in self.counter_info:
+            self.metrics[counter_name] = CounterMetricFamily(
+                'infiniband_' + counter_name.lower(),
+                self.counter_info[counter_name]['help'],
+                labels=[
+                    'local_name',
+                    'local_guid',
+                    'local_port',
+                    'remote_guid',
+                    'remote_port',
+                    'remote_name'
+                ])
+
     def parse_switch(self, switch_name, match_port, match_link):
 
         guid = match_port.group(1)
@@ -286,7 +314,9 @@ catched on stderr of ibqueryerrors'
                 self.reset_counter(guid, port, counter)
 
     def collect(self):
+
         logging.debug('Start of collection cycle')
+
         ibqueryerrors_duration = GaugeMetricFamily(
             'infiniband_ibqueryerrors_duration_seconds',
             'Number of seconds taken to run ibqueryerrors')
@@ -298,6 +328,8 @@ catched on stderr of ibqueryerrors'
             'infiniband_scrape_ok',
             'Indicate with a 1 if the scrape is valid, otherwise 0 if errors \
 were encountered')
+
+        self.init_switch_metrics()
 
         scrape_with_errors = False
 
@@ -359,31 +391,6 @@ were encountered')
             raise RuntimeError("Inconsistent input content detected: {}".format(content[0]))
 
         switches = self.chunks(content, 2)
-
-        for gauge_name in self.gauge_info:
-            self.metrics[gauge_name] = GaugeMetricFamily(
-                'infiniband_' + gauge_name.lower(),
-                self.gauge_info[gauge_name]['help'],
-                labels=[
-                    'local_name',
-                    'local_guid',
-                    'local_port',
-                    'remote_guid',
-                    'remote_port',
-                    'remote_name'
-                ])
-        for counter_name in self.counter_info:
-            self.metrics[counter_name] = CounterMetricFamily(
-                'infiniband_' + counter_name.lower(),
-                self.counter_info[counter_name]['help'],
-                labels=[
-                    'local_name',
-                    'local_guid',
-                    'local_port',
-                    'remote_guid',
-                    'remote_port',
-                    'remote_name'
-                ])
 
         for switch in switches:
 

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -350,11 +350,13 @@ were encountered')
                            flags=re.MULTILINE)
 
         if not content:
-            raise RuntimeError('Split contant from ibqueryerrors_stdout is empty.')
+            raise RuntimeError('Split content from ibqueryerrors_stdout is empty.')
 
-        # Drop first line retrieved from re.split(), if empty.
+        # Drop first line that is empty on successful regex split():
         if content[0] == '':
             del content[0]
+        else:
+            raise RuntimeError("Inconsistent input content detected: {}".format(content[0]))
 
         switches = self.chunks(content, 2)
 

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -255,30 +255,30 @@ catched on stderr of ibqueryerrors'
         else:
             return False
 
-    def parse_switch(self, switch_name, m_port, m_link):
+    def parse_switch(self, switch_name, match_port, match_link):
 
-        guid = m_port.group(1)
-        port = m_port.group(2)
-        counters = self.parse_counter(m_port.group(3))
+        guid = match_port.group(1)
+        port = match_port.group(2)
+        counters = self.parse_counter(match_port.group(3))
 
         for gauge in self.gauge_info.keys():
             self.metrics[gauge].add_metric([
                 switch_name,
                 guid,
                 port,
-                m_link.group('remote_GUID'),
-                m_link.group('remote_port'),
-                m_link.group('node_name')],
-                m_link.group(gauge))
+                match_link.group('remote_GUID'),
+                match_link.group('remote_port'),
+                match_link.group('node_name')],
+                match_link.group(gauge))
 
         for counter in counters:
             self.metrics[counter].add_metric([
                 switch_name,
                 guid,
                 port,
-                m_link.group('remote_GUID'),
-                m_link.group('remote_port'),
-                m_link.group('node_name')],
+                match_link.group('remote_GUID'),
+                match_link.group('remote_port'),
+                match_link.group('node_name')],
                 counters[counter])
 
             if counters[counter] >= 2 ** (self.counter_info[counter]['bits'] - 1):  # noqa: E501
@@ -404,23 +404,23 @@ were encountered')
 
                     port_item, link_item = switch_port_item
 
-                    m_port = self.pattern_switch_port.match(port_item)
+                    match_port = self.pattern_switch_port.match(port_item)
 
-                    if m_port:
+                    if match_port:
 
-                        port = int(m_port.group(2))
+                        port = int(match_port.group(2))
 
                         if port > 0:
 
-                            m_link = self.pattern_switch_link.match(link_item)
+                            match_link = self.pattern_switch_link.match(link_item)
 
-                            if not m_link:
+                            if not match_link:
                                 raise RuntimeError('No link info line match for port: {}'.format(port_item))
 
                             m_active_link = self.pattern_switch_active_link.match(link_item)
 
                             if m_active_link:
-                                self.parse_switch(switch_name, m_port, m_active_link)
+                                self.parse_switch(switch_name, match_port, m_active_link)
 
                     elif not port_item or "##" in port_item:
 

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -385,6 +385,9 @@ were encountered')
 
         for switch in switches:
 
+            if len(switch) != 2:
+                raise RuntimeError('Switch data incomplete: {}'.format(switch[0]))
+
             switch_name = switch[0]
             switch_data = switch[1]
 

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -177,7 +177,7 @@ catched on stderr of ibqueryerrors'
         self.bad_status_error_pattern = r'src\/query\_smp\.c\:[\d]+\; (?:mad|umad) \((DR path .*) Attr .*\) bad status ([\d]+); (.*)'  # noqa: E501
         self.bad_status_error_prog = re.compile(self.bad_status_error_pattern)
 
-        self.switch_header_regex_str = r'^Errors for (.*) \"(.*)\"'
+        self.switch_header_regex_str = r'^Errors for 0[x][\da-f]+ \"(.*)\"'
         self.switch_all_ports_pattern = re.compile(r'GUID 0[x][\da-f]+ port ALL: (?:\[.*\])+')
 
         # TODO: Will be the same regex objects for HCA. Remove 'switch' in name then...
@@ -356,7 +356,7 @@ were encountered')
         if content[0] == '':
             del content[0]
 
-        switches = self.chunks(content, 3)
+        switches = self.chunks(content, 2)
 
         for gauge_name in self.gauge_info:
             self.metrics[gauge_name] = GaugeMetricFamily(
@@ -385,8 +385,8 @@ were encountered')
 
         for switch in switches:
 
-            switch_name = switch[1]
-            switch_data = switch[2]
+            switch_name = switch[0]
+            switch_data = switch[1]
 
             switch_items = switch_data.lstrip().splitlines()
             switch_all_ports = switch_items[0]


### PR DESCRIPTION
Hi,

you ran into it before I could create an issue for this :-).

I see the problem with your implemented error catch in https://github.com/guilbaults/infiniband-exporter/pull/33 that just catching the error and printing it, will not help us much, because we need to recognize that there went something wrong.

We can handle it as you did in the above implementation and do not crash the exporter.  
But then we need to show up that there happened something wrong in the exporter, for that I have set the `scrape_ok` metric to 0.  

So we can check if that metric was set to 0 on non critical errors during exporter scrapes.

