### PR TITLE
Implement PortSwHOQLifetimeLimitDiscards metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,20 +89,21 @@ Labels list:
 
 #### Error Counter
 
-| Name                        | Description                                                                                                           |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| LinkDownedCounter           | Total number of times the Port Training state machine has failed the link error recovery process and downed the link. |
-| SymbolErrorCounter          | Total number of minor link errors detected on one or more physical lanes.                                             |
-| PortXmitDiscards            | Total number of outbound packets discarded by the port because the port is down or congested.                         |
-| PortBufferOverrunErrors     | Total number of packets received on the part discarded due to buffer overrrun.                                        |
-| PortLocalPhysicalErrors     | Total number of packets received with physical error like CRC error.                                                  |
-| PortRcvRemotePhysicalErrors | Total number of packets marked with the EBP delimiter received on the port.                                           |
-| PortInactiveDiscards        | Total number of packets discarded due to the port being in the inactive state.                                        |
-| PortDLIDMappingErrors       | Total number of packets on the port that could not be forwared by the switch due to DLID mapping errors.              |
-| LinkErrorRecoveryCounter    | Total number of times the Port Training state machine has successfully completed the link error recovery process.     |
-| LocalLinkIntegrityErrors    | The number of times that the count of local physical errors exceeded the threshold specified by LocalPhyErrors.       |
-| VL15Dropped                 | The number of incoming VL15 packets dropped due to resource limitations (for example, lack of buffers) in the port.   |
-| PortNeighborMTUDiscards     | Total outbound packets discarded by the port because packet length exceeded the neighbor MTU.                         |
+| Name                          | Description                                                                                                           |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| LinkDownedCounter             | Total number of times the Port Training state machine has failed the link error recovery process and downed the link. |
+| SymbolErrorCounter            | Total number of minor link errors detected on one or more physical lanes.                                             |
+| PortXmitDiscards              | Total number of outbound packets discarded by the port because the port is down or congested.                         |
+| PortSwHOQLifetimeLimitDiscards| Total number of outbound packets discarded because they ran into a head-of-Queue timeout.                             |
+| PortBufferOverrunErrors       | Total number of packets received on the part discarded due to buffer overrrun.                                        |
+| PortLocalPhysicalErrors       | Total number of packets received with physical error like CRC error.                                                  |
+| PortRcvRemotePhysicalErrors   | Total number of packets marked with the EBP delimiter received on the port.                                           |
+| PortInactiveDiscards          | Total number of packets discarded due to the port being in the inactive state.                                        |
+| PortDLIDMappingErrors         | Total number of packets on the port that could not be forwared by the switch due to DLID mapping errors.              |
+| LinkErrorRecoveryCounter      | Total number of times the Port Training state machine has successfully completed the link error recovery process.     |
+| LocalLinkIntegrityErrors      | The number of times that the count of local physical errors exceeded the threshold specified by LocalPhyErrors.       |
+| VL15Dropped                   | The number of incoming VL15 packets dropped due to resource limitations (for example, lack of buffers) in the port.   |
+| PortNeighborMTUDiscards       | Total outbound packets discarded by the port because packet length exceeded the neighbor MTU.                         |
 
 #### Informative Counter
 

--- a/infiniband-exporter-el7.spec
+++ b/infiniband-exporter-el7.spec
@@ -1,5 +1,5 @@
 Name:	  infiniband-exporter
-Version:  0.0.4
+Version:  0.0.5
 %global gittag 0.0.4
 Release:  1%{?dist}
 Summary:  Prometheus exporter for a Infiniband Fabric

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -65,7 +65,7 @@ class InfinibandCollector(object):
             'PortSwHOQLifetimeLimitDiscards': {
                 'help': 'The number of packets dropped by running in a head-of-Queue timeout'
                         'often caused by congestions, possibly by credit Loops.',
-                'severity': 'Informative',
+                'severity': 'Error',
                 'bits': 16,
             },
             'PortXmitWait': {

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -13,7 +13,7 @@ from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 from prometheus_client import make_wsgi_app
 from wsgiref.simple_server import make_server, WSGIRequestHandler
 
-VERSION = "0.0.4"
+VERSION = "0.0.5"
 
 class ParsingError(Exception):
     pass
@@ -59,6 +59,13 @@ class InfinibandCollector(object):
                 'help': 'Total number of outbound packets discarded by the '
                         'port because the port is down or congested.',
                 'severity': 'Error',
+                'bits': 16,
+            },
+            # detailed description of xmitDiscards: (Head of Queue) timeout https://community.mellanox.com/s/article/howto-prevent-infiniband-credit-loops
+            'PortSwHOQLifetimeLimitDiscards': {
+                'help': 'The number of packets dropped by running in a head-of-Queue timeout'
+                        'often caused by congestions, possibly by credit Loops.',
+                'severity': 'Informative',
                 'bits': 16,
             },
             'PortXmitWait': {


### PR DESCRIPTION
Implements the PortSwHOQLifetiemLimitDiscards, which is a finer grained congestion metric of xmitDiscards.
Prior to this, the infiniband scraper returned false, as we had errors in the like of 
```
2021-11-10 18:30:43,587 - ERROR - Missing description for counter metric: PortSwHOQLifetimeLimitDiscards
```
There are [even more detailed metrics]( https://patchwork.kernel.org/project/linux-rdma/patch/0F3DDD57-C1A9-4304-A20F-7027BF8F590B@llnl.gov/) that were added at the same time, which could potentially also evoke this behaviour. I can open an Issue for this, if you want.

I have updated the minor `Version` in the `.py` and `.spec` files, but did not change the `gittag`