### PR TITLE
Add three new error counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Labels list:
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | LinkDownedCounter             | Total number of times the Port Training state machine has failed the link error recovery process and downed the link. |
 | SymbolErrorCounter            | Total number of minor link errors detected on one or more physical lanes.                                             |
+| PortXmitConstraintErrors      | Total number of packets not transmitted from the switch physical port
+| PortMalformedPktErrors        | Total number of malformed packets
+| PortSwLifetimeLimitDiscards   | Total number of lifetime limit discards
 | PortXmitDiscards              | Total number of outbound packets discarded by the port because the port is down or congested.                         |
 | PortSwHOQLifetimeLimitDiscards| Total number of outbound packets discarded because they ran into a head-of-Queue timeout.                             |
 | PortBufferOverrunErrors       | Total number of packets received on the part discarded due to buffer overrrun.                                        |

--- a/infiniband-exporter-el7.spec
+++ b/infiniband-exporter-el7.spec
@@ -1,6 +1,6 @@
 Name:	  infiniband-exporter
-Version:  0.0.5
-%global gittag 0.0.5
+Version:  0.0.6
+%global gittag 0.0.6
 Release:  1%{?dist}
 Summary:  Prometheus exporter for a Infiniband Fabric
 

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -13,7 +13,7 @@ from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 from prometheus_client import make_wsgi_app
 from wsgiref.simple_server import make_server, WSGIRequestHandler
 
-VERSION = "0.0.5"
+VERSION = "0.0.6"
 
 class ParsingError(Exception):
     pass
@@ -52,6 +52,21 @@ class InfinibandCollector(object):
             'SymbolErrorCounter': {
                 'help': 'Total number of minor link errors detected on one '
                         'or more physical lanes.',
+                'severity': 'Error',
+                'bits': 16,
+            },
+            'PortXmitConstraintErrors': {
+                'help': 'Total number of packets not transmitted from the switch physical port',
+                'severity': 'Error',
+                'bits': 16,
+            },
+            'PortMalformedPktErrors': {
+                'help': 'Total number of malformed packets',
+                'severity': 'Error',
+                'bits': 16,
+            },
+            'PortSwLifetimeLimitDiscards': {
+                'help': 'Total number of lifetime limit discards',
                 'severity': 'Error',
                 'bits': 16,
             },


### PR DESCRIPTION
Add these three error counters:
| PortXmitConstraintErrors      | Total number of packets not transmitted from the switch physical port
| PortMalformedPktErrors        | Total number of malformed packets
| PortSwLifetimeLimitDiscards   | Total number of lifetime limit discards