### PR TITLE
Add PortRcvConstraintErrors and ExcessiveBufferOverrunErrors counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Labels list:
 | LocalLinkIntegrityErrors      | The number of times that the count of local physical errors exceeded the threshold specified by LocalPhyErrors.       |
 | VL15Dropped                   | The number of incoming VL15 packets dropped due to resource limitations (for example, lack of buffers) in the port.   |
 | PortNeighborMTUDiscards       | Total outbound packets discarded by the port because packet length exceeded the neighbor MTU.                         |
+| PortRcvConstraintErrors       | Total number of packets received on the port that are discarded for any of the following reasons: - FilterRawInbound is true and packet is raw - PartitionEnforcementInbound is true and packet fails partition key check, IP version check, or transport header version check. |
+| ExcessiveBufferOverrunErrors  | The number of times that consecutive flow control update periods had at least one overrun error. |
 
 #### Informative Counter
 

--- a/infiniband-exporter.py
+++ b/infiniband-exporter.py
@@ -203,6 +203,21 @@ class InfinibandCollector(object):
                         'packet length exceeded the neighbor MTU.',
                 'severity': 'Error',
                 'bits': 16,
+            },
+            'PortRcvConstraintErrors': {
+                'help': 'Total number of packets received on the port that are discarded '
+                        'for any of the following reasons: - FilterRawInbound is true and '
+                        'packet is raw - PartitionEnforcementInbound is true and packet '
+                        'fails partition key check, IP version check, or transport header '
+                        'version check.',
+                'severity': 'Error',
+                'bits': 16,
+            },
+            'ExcessiveBufferOverrunErrors': {
+                'help': 'The number of times that consecutive flow control update periods '
+                        'had at least one overrun error.',
+                'severity': 'Error',
+                'bits': 16,
             }
         }
         self.gauge_info = {


### PR DESCRIPTION
Add `PortRcvConstraintErrors` and `ExcessiveBufferOverrunErrors` counters based on descriptions found here https://schemas.dmtf.org/wbem/cim-html/2.38.0+/CIM_IBPortStatistics.html. 

These counters are showing up with ibqueryerrors from rdma-core v40.0 on our EDR fabric.